### PR TITLE
Symfony 8 support and improvements

### DIFF
--- a/.github/workflows/ci-php.yml
+++ b/.github/workflows/ci-php.yml
@@ -1,21 +1,35 @@
-name: Unit Tests
+name: Tests
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
 
 jobs:
   test:
-
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
-        php: ['7.4', '8.2']
+        php: ['7.4', '8.1', '8.2', '8.3', '8.4']
         dependency-version: [prefer-stable]
+
+    name: PHP ${{ matrix.php }}
+
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v7
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: soap
+          coverage: none
 
       - name: Install dependencies
-        run: composer install --no-suggest
+        run: composer install --no-interaction --prefer-dist
 
-      - name: Run integration test suite
+      - name: Run unit tests
+        run: vendor/bin/simple-phpunit --testsuite=unit
+
+      - name: Run integration tests
         run: vendor/bin/simple-phpunit --testsuite=integration

--- a/.github/workflows/ci-php.yml
+++ b/.github/workflows/ci-php.yml
@@ -10,10 +10,29 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.4', '8.1', '8.2', '8.3', '8.4']
-        dependency-version: [prefer-stable]
+        include:
+          - php: '7.4'
+            symfony: '^4.4'
+          - php: '7.4'
+            symfony: '^5.4'
+          - php: '8.1'
+            symfony: '^5.4'
+          - php: '8.1'
+            symfony: '^6.4'
+          - php: '8.2'
+            symfony: '^6.4'
+          - php: '8.2'
+            symfony: '^7.4'
+          - php: '8.2'
+            symfony: '^7.4'
+          - php: '8.3'
+            symfony: '^7.4'
+          - php: '8.4'
+            symfony: '^7.4'
+          - php: '8.4'
+            symfony: '^8.0'
 
-    name: PHP ${{ matrix.php }}
+    name: PHP ${{ matrix.php }} / Symfony ${{ matrix.symfony }}
 
     steps:
       - uses: actions/checkout@v7
@@ -25,8 +44,17 @@ jobs:
           extensions: soap
           coverage: none
 
+      - name: Configure Composer
+        run: composer config --global policy.advisories.block false
+
       - name: Install dependencies
-        run: composer install --no-interaction --prefer-dist
+        run: |
+          composer require \
+            "symfony/framework-bundle:${{ matrix.symfony }}" \
+            "symfony/yaml:${{ matrix.symfony }}" \
+            "symfony/http-client:${{ matrix.symfony }}" \
+            --dev --no-update --no-interaction
+          composer update --no-interaction --prefer-dist
 
       - name: Run unit tests
         run: vendor/bin/simple-phpunit --testsuite=unit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Değişiklik Geçmişi
+
+## [1.3.0] - 2026-06-22
+
+### Eklendi
+- Symfony v8 desteği eklendi.
+
+### Düzeltildi
+- Gateway nesneleri oluşturan kodlar iyileştirildi.
+
+### Yeniden Düzenlendi
+- Bundle konfigurasyonunda bundle tarafından desteklenmeyen bir `gateway_class` (örneğin `mews/pos`'a eklenen yeni gateway sınıfı)
+  tanımlandığında artık açıklayıcı bir `InvalidArgumentException` fırlatılıyor. Eskiden sessizce ignore ediliyordu.
+- KuveytPos için PHP `ext-soap` eklendi zorunluluğu kaldırıldı.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 ## Minimum Gereksinimler
   - PHP >= 7.4
   - mews/pos ^1.7
-  - Symfony 4|5|6|7
+  - Symfony 4|5|6|7|8
 
 ## Kurulum
 1. 

--- a/composer.json
+++ b/composer.json
@@ -31,20 +31,21 @@
     "require": {
         "php": ">=7.4",
         "mews/pos": "^1.7",
-        "symfony/config": "^4.0 | ^5.0 | ^6.0 | ^7.0",
-        "symfony/dependency-injection": "^4.0 | ^5.0 | ^6.0 | ^7.0",
-        "symfony/event-dispatcher": "^4.0 | ^5.0 | ^6.0 | ^7.0",
-        "symfony/http-kernel": "^4.0 | ^5.0 | ^6.0 | ^7.0",
-        "symfony/options-resolver": "^4.0 | ^5.0 | ^6.0 | ^7.0"
+        "psr/event-dispatcher": "^1.0",
+        "symfony/config": "^4.0 | ^5.0 | ^6.0 | ^7.0 | ^8.0",
+        "symfony/dependency-injection": "^4.0 | ^5.0 | ^6.0 | ^7.0 | ^8.0",
+        "symfony/event-dispatcher": "^4.0 | ^5.0 | ^6.0 | ^7.0 | ^8.0",
+        "symfony/http-kernel": "^4.0 | ^5.0 | ^6.0 | ^7.0 | ^8.0",
+        "symfony/options-resolver": "^4.0 | ^5.0 | ^6.0 | ^7.0 | ^8.0"
     },
     "require-dev": {
         "nyholm/psr7": "^1.8",
         "psr/http-client": "^1.0",
-        "symfony/framework-bundle": "^6.4",
-        "symfony/http-client": "^6.4",
-        "symfony/monolog-bundle": "^3.10",
-        "symfony/phpunit-bridge": "^6.4",
-        "symfony/yaml": "^6.4"
+        "symfony/framework-bundle": "^8.0",
+        "symfony/http-client": "^8.0",
+        "symfony/monolog-bundle": "^3.1",
+        "symfony/phpunit-bridge": "^5.4 | ^6.4 | ^7.4 | ^8.0",
+        "symfony/yaml": "^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -15,6 +15,9 @@
         <testsuite name="default">
             <directory>tests</directory>
         </testsuite>
+        <testsuite name="unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
         <testsuite name="integration">
             <directory>tests/Integration</directory>
         </testsuite>

--- a/src/DependencyInjection/MewsPosExtension.php
+++ b/src/DependencyInjection/MewsPosExtension.php
@@ -22,32 +22,31 @@ class MewsPosExtension extends Extension
         // Create gateway definition
         foreach ($config['banks'] as $bank => $bankConfigs) {
 
-            if ($gatewayDefinition = $definitionFactory->createDefinition($bank, $bankConfigs)) {
-                $serviceId = 'mews_pos.gateway.'.$bank;
+            $gatewayDefinition = $definitionFactory->createDefinition($bank, $bankConfigs);
+            $serviceId = 'mews_pos.gateway.'.$bank;
 
-                $container->setDefinition($serviceId, $gatewayDefinition)
-                    ->setClass(PosInterface::class)
-                    ->setFactory([GatewayFactory::class, 'createPosGateway'])
-                    ->setArguments([
-                        '$name'            => $bank,
-                        '$options'         => $bankConfigs,
-                        '$eventDispatcher' => new Reference('event_dispatcher'),
-                        '$logger'          => new Reference('logger'),
-                        '$client'          => new Reference('psr18.http_client'),
-                    ])
+            $container->setDefinition($serviceId, $gatewayDefinition)
+                ->setClass(PosInterface::class)
+                ->setFactory([GatewayFactory::class, 'createPosGateway'])
+                ->setArguments([
+                    '$name'            => $bank,
+                    '$options'         => $bankConfigs,
+                    '$eventDispatcher' => new Reference('event_dispatcher'),
+                    '$logger'          => new Reference('logger'),
+                    '$client'          => new Reference('psr18.http_client'),
+                ])
+                ->setPublic(false);
+
+            $container->registerAliasForArgument($serviceId, PosInterface::class, $bank)
+                ->setPublic(false);
+
+            $gatewayDefinition->addTag('mews_pos.gateway', ['key' => $serviceId]);
+
+            if ($i === 0) {
+                // set the first gateway as a default for injection
+                $container->setAlias(PosInterface::class, $serviceId)
                     ->setPublic(false);
-
-                $container->registerAliasForArgument($serviceId, PosInterface::class, $bank)
-                    ->setPublic(false);
-
-                $gatewayDefinition->addTag('mews_pos.gateway', ['key' => $serviceId]);
-
-                if ($i === 0) {
-                    // set the first gateway as a default for injection
-                    $container->setAlias(PosInterface::class, $serviceId)
-                        ->setPublic(false);
-                    $i++;
-                }
+                $i++;
             }
         }
     }

--- a/src/Gateway/AccountFactory.php
+++ b/src/Gateway/AccountFactory.php
@@ -145,7 +145,7 @@ class AccountFactory
         }
 
         throw new \DomainException(
-            \sprintf('Can not create matching Account object for % gateway', $gatewayClass)
+            \sprintf('Can not create matching Account object for %s gateway', $gatewayClass)
         );
     }
 }

--- a/src/Gateway/Builder/AbstractGatewayDefinitionBuilder.php
+++ b/src/Gateway/Builder/AbstractGatewayDefinitionBuilder.php
@@ -92,9 +92,9 @@ abstract class AbstractGatewayDefinitionBuilder implements GatewayDefinitionBuil
     private function ensureRequiredExtensionsAvailable(string $name): void
     {
         $missingExtensions = [];
-        foreach ($this->getRequiredExtensions() as $requiredClass => $extension) {
-            if (!\class_exists($requiredClass)) {
-                $missingExtensions[] = $extension;
+        foreach ($this->getRequiredExtensions() as $extensionName => $displayName) {
+            if (!\extension_loaded($extensionName)) {
+                $missingExtensions[] = $displayName;
             }
         }
 

--- a/src/Gateway/Builder/AbstractGatewayDefinitionBuilder.php
+++ b/src/Gateway/Builder/AbstractGatewayDefinitionBuilder.php
@@ -41,7 +41,7 @@ abstract class AbstractGatewayDefinitionBuilder implements GatewayDefinitionBuil
             ->setRequired('gateway_class')
             ->setAllowedTypes('gateway_class', 'string');
 
-        $resolver->setDefault('gateway_endpoints', function (OptionsResolver $subResolver): void {
+        $this->setNestedOptions($resolver, 'gateway_endpoints', function (OptionsResolver $subResolver): void {
             $required = $this->getRequiredEndpoints();
             $optional = $this->getOptionalEndpoints();
 
@@ -54,7 +54,7 @@ abstract class AbstractGatewayDefinitionBuilder implements GatewayDefinitionBuil
             }
         });
 
-        $resolver->setDefault('credentials', function (OptionsResolver $subResolver): void {
+        $this->setNestedOptions($resolver, 'credentials', function (OptionsResolver $subResolver): void {
             $subResolver->setRequired([
                 'merchant_id',
                 'payment_model',
@@ -71,7 +71,7 @@ abstract class AbstractGatewayDefinitionBuilder implements GatewayDefinitionBuil
             ]);
         });
 
-        $resolver->setDefault('gateway_configs', function (OptionsResolver $subResolver): void {
+        $this->setNestedOptions($resolver, 'gateway_configs', function (OptionsResolver $subResolver): void {
             $subResolver->setDefault('test_mode', false)
                 ->setAllowedTypes('test_mode', 'boolean');
             $subResolver->setDefault('disable_3d_hash_check', false)
@@ -87,6 +87,19 @@ abstract class AbstractGatewayDefinitionBuilder implements GatewayDefinitionBuil
     protected function getOptionalEndpoints(): array
     {
         return ['gateway_3d_host'];
+    }
+
+    /**
+     * Uses setOptions() (Symfony >=7.3) when available, falls back to setDefault() for older versions.
+     * setDefault() with a nested OptionsResolver closure was removed in Symfony 8.0.
+     */
+    protected function setNestedOptions(OptionsResolver $resolver, string $name, \Closure $configurator): void
+    {
+        if (\method_exists($resolver, 'setOptions')) {
+            $resolver->setOptions($name, $configurator);
+        } else {
+            $resolver->setDefault($name, $configurator);
+        }
     }
 
     private function ensureRequiredExtensionsAvailable(string $name): void

--- a/src/Gateway/Builder/AbstractGatewayDefinitionBuilder.php
+++ b/src/Gateway/Builder/AbstractGatewayDefinitionBuilder.php
@@ -42,14 +42,16 @@ abstract class AbstractGatewayDefinitionBuilder implements GatewayDefinitionBuil
             ->setAllowedTypes('gateway_class', 'string');
 
         $resolver->setDefault('gateway_endpoints', function (OptionsResolver $subResolver): void {
-            $subResolver->setDefined([
-                'gateway_3d_host',
-            ]);
-            $subResolver->setRequired([
-                'payment_api',
-            ]);
-            $subResolver->setAllowedTypes('payment_api', ['string']);
-            $subResolver->setAllowedTypes('gateway_3d_host', ['string']);
+            $required = $this->getRequiredEndpoints();
+            $optional = $this->getOptionalEndpoints();
+
+            $subResolver->setRequired($required);
+            if ($optional) {
+                $subResolver->setDefined($optional);
+            }
+            foreach (\array_merge($required, $optional) as $key) {
+                $subResolver->setAllowedTypes($key, 'string');
+            }
         });
 
         $resolver->setDefault('credentials', function (OptionsResolver $subResolver): void {
@@ -77,14 +79,14 @@ abstract class AbstractGatewayDefinitionBuilder implements GatewayDefinitionBuil
         });
     }
 
-    protected function require3DGateway(OptionsResolver $resolver): void
+    protected function getRequiredEndpoints(): array
     {
-        $resolver->setDefault('gateway_endpoints', function (OptionsResolver $subResolver): void {
-            $subResolver->setRequired([
-                'gateway_3d',
-            ]);
-            $subResolver->setAllowedTypes('gateway_3d', ['string']);
-        });
+        return ['payment_api'];
+    }
+
+    protected function getOptionalEndpoints(): array
+    {
+        return ['gateway_3d_host'];
     }
 
     private function ensureRequiredExtensionsAvailable(string $name): void

--- a/src/Gateway/Builder/AkbankPosDefinitionBuilder.php
+++ b/src/Gateway/Builder/AkbankPosDefinitionBuilder.php
@@ -24,7 +24,7 @@ class AkbankPosDefinitionBuilder extends AbstractGatewayDefinitionBuilder
     {
         parent::configureOptions($resolver);
 
-        $resolver->setDefault('credentials', function (OptionsResolver $subResolver): void {
+        $this->setNestedOptions($resolver, 'credentials', function (OptionsResolver $subResolver): void {
             $subResolver
                 ->setRequired('terminal_id')
                 ->setAllowedTypes('terminal_id', ['string', 'int']);

--- a/src/Gateway/Builder/AkbankPosDefinitionBuilder.php
+++ b/src/Gateway/Builder/AkbankPosDefinitionBuilder.php
@@ -33,6 +33,10 @@ class AkbankPosDefinitionBuilder extends AbstractGatewayDefinitionBuilder
                 ->setAllowedTypes('sub_merchant_id', ['string', 'int']);
         });
 
-        $this->require3DGateway($resolver);
+    }
+
+    protected function getRequiredEndpoints(): array
+    {
+        return \array_merge(parent::getRequiredEndpoints(), ['gateway_3d']);
     }
 }

--- a/src/Gateway/Builder/EstV3PosDefinitionBuilder.php
+++ b/src/Gateway/Builder/EstV3PosDefinitionBuilder.php
@@ -34,6 +34,10 @@ class EstV3PosDefinitionBuilder extends AbstractGatewayDefinitionBuilder
             $subResolver->setAllowedTypes('user_password', ['int', 'string']);
         });
 
-        $this->require3DGateway($resolver);
+    }
+
+    protected function getRequiredEndpoints(): array
+    {
+        return \array_merge(parent::getRequiredEndpoints(), ['gateway_3d']);
     }
 }

--- a/src/Gateway/Builder/EstV3PosDefinitionBuilder.php
+++ b/src/Gateway/Builder/EstV3PosDefinitionBuilder.php
@@ -25,7 +25,7 @@ class EstV3PosDefinitionBuilder extends AbstractGatewayDefinitionBuilder
     {
         parent::configureOptions($resolver);
 
-        $resolver->setDefault('credentials', function (OptionsResolver $subResolver): void {
+        $this->setNestedOptions($resolver, 'credentials', function (OptionsResolver $subResolver): void {
             $subResolver->setRequired([
                 'user_name',
                 'user_password',

--- a/src/Gateway/Builder/GarantiPosDefinitionBuilder.php
+++ b/src/Gateway/Builder/GarantiPosDefinitionBuilder.php
@@ -42,6 +42,10 @@ class GarantiPosDefinitionBuilder extends AbstractGatewayDefinitionBuilder
             $subResolver->setAllowedTypes('refund_user_password', ['int', 'string']);
         });
 
-        $this->require3DGateway($resolver);
+    }
+
+    protected function getRequiredEndpoints(): array
+    {
+        return \array_merge(parent::getRequiredEndpoints(), ['gateway_3d']);
     }
 }

--- a/src/Gateway/Builder/GarantiPosDefinitionBuilder.php
+++ b/src/Gateway/Builder/GarantiPosDefinitionBuilder.php
@@ -24,7 +24,7 @@ class GarantiPosDefinitionBuilder extends AbstractGatewayDefinitionBuilder
     {
         parent::configureOptions($resolver);
 
-        $resolver->setDefault('credentials', function (OptionsResolver $subResolver): void {
+        $this->setNestedOptions($resolver, 'credentials', function (OptionsResolver $subResolver): void {
             $subResolver->setRequired([
                 'user_name',
                 'user_password',

--- a/src/Gateway/Builder/InterPosDefinitionBuilder.php
+++ b/src/Gateway/Builder/InterPosDefinitionBuilder.php
@@ -34,6 +34,10 @@ class InterPosDefinitionBuilder extends AbstractGatewayDefinitionBuilder
             $subResolver->setAllowedTypes('user_password', ['int', 'string']);
         });
 
-        $this->require3DGateway($resolver);
+    }
+
+    protected function getRequiredEndpoints(): array
+    {
+        return \array_merge(parent::getRequiredEndpoints(), ['gateway_3d']);
     }
 }

--- a/src/Gateway/Builder/InterPosDefinitionBuilder.php
+++ b/src/Gateway/Builder/InterPosDefinitionBuilder.php
@@ -25,7 +25,7 @@ class InterPosDefinitionBuilder extends AbstractGatewayDefinitionBuilder
     {
         parent::configureOptions($resolver);
 
-        $resolver->setDefault('credentials', function (OptionsResolver $subResolver): void {
+        $this->setNestedOptions($resolver, 'credentials', function (OptionsResolver $subResolver): void {
             $subResolver->setRequired([
                 'user_name',
                 'user_password',

--- a/src/Gateway/Builder/KuveytPosDefinitionBuilder.php
+++ b/src/Gateway/Builder/KuveytPosDefinitionBuilder.php
@@ -26,14 +26,6 @@ class KuveytPosDefinitionBuilder extends AbstractGatewayDefinitionBuilder
     {
         parent::configureOptions($resolver);
 
-        $resolver->setDefault('gateway_endpoints', function (OptionsResolver $subResolver): void {
-            $subResolver
-                ->setRequired('query_api')
-                ->setAllowedTypes('query_api', 'string');
-        });
-
-        $this->require3DGateway($resolver);
-
         $resolver->setDefault('credentials', function (OptionsResolver $subResolver): void {
             $subResolver->setRequired([
                 'user_name',
@@ -43,5 +35,10 @@ class KuveytPosDefinitionBuilder extends AbstractGatewayDefinitionBuilder
                 ->setDefined('sub_merchant_id')
                 ->setAllowedTypes('sub_merchant_id', ['int', 'string']);
         });
+    }
+
+    protected function getRequiredEndpoints(): array
+    {
+        return \array_merge(parent::getRequiredEndpoints(), ['gateway_3d', 'query_api']);
     }
 }

--- a/src/Gateway/Builder/KuveytPosDefinitionBuilder.php
+++ b/src/Gateway/Builder/KuveytPosDefinitionBuilder.php
@@ -18,7 +18,7 @@ class KuveytPosDefinitionBuilder extends AbstractGatewayDefinitionBuilder
     protected function getRequiredExtensions(): array
     {
         return [
-            'SoapClient' => 'ext-soap',
+            'soap' => 'ext-soap',
         ];
     }
 

--- a/src/Gateway/Builder/KuveytPosDefinitionBuilder.php
+++ b/src/Gateway/Builder/KuveytPosDefinitionBuilder.php
@@ -26,7 +26,7 @@ class KuveytPosDefinitionBuilder extends AbstractGatewayDefinitionBuilder
     {
         parent::configureOptions($resolver);
 
-        $resolver->setDefault('credentials', function (OptionsResolver $subResolver): void {
+        $this->setNestedOptions($resolver, 'credentials', function (OptionsResolver $subResolver): void {
             $subResolver->setRequired([
                 'user_name',
                 'terminal_id',

--- a/src/Gateway/Builder/KuveytPosDefinitionBuilder.php
+++ b/src/Gateway/Builder/KuveytPosDefinitionBuilder.php
@@ -17,9 +17,7 @@ class KuveytPosDefinitionBuilder extends AbstractGatewayDefinitionBuilder
 
     protected function getRequiredExtensions(): array
     {
-        return [
-            'soap' => 'ext-soap',
-        ];
+        return [];
     }
 
     protected function configureOptions(OptionsResolver $resolver): void

--- a/src/Gateway/Builder/ParamPosDefinitionBuilder.php
+++ b/src/Gateway/Builder/ParamPosDefinitionBuilder.php
@@ -33,10 +33,10 @@ class ParamPosDefinitionBuilder extends AbstractGatewayDefinitionBuilder
             $subResolver->setAllowedTypes('user_password', ['int', 'string']);
         });
 
-        $resolver->setDefault('gateway_endpoints', function (OptionsResolver $subResolver): void {
-            $subResolver
-                ->setDefined('payment_api_2') // for 3D Host
-                ->setAllowedTypes('payment_api_2', 'string');
-        });
+    }
+
+    protected function getOptionalEndpoints(): array
+    {
+        return \array_merge(parent::getOptionalEndpoints(), ['payment_api_2']);
     }
 }

--- a/src/Gateway/Builder/ParamPosDefinitionBuilder.php
+++ b/src/Gateway/Builder/ParamPosDefinitionBuilder.php
@@ -24,7 +24,7 @@ class ParamPosDefinitionBuilder extends AbstractGatewayDefinitionBuilder
     {
         parent::configureOptions($resolver);
 
-        $resolver->setDefault('credentials', function (OptionsResolver $subResolver): void {
+        $this->setNestedOptions($resolver, 'credentials', function (OptionsResolver $subResolver): void {
             $subResolver->setRequired([
                 'user_name',
                 'user_password',

--- a/src/Gateway/Builder/PayFlexCPV4PosDefinitionBuilder.php
+++ b/src/Gateway/Builder/PayFlexCPV4PosDefinitionBuilder.php
@@ -24,8 +24,6 @@ class PayFlexCPV4PosDefinitionBuilder extends AbstractGatewayDefinitionBuilder
     {
         parent::configureOptions($resolver);
 
-        $this->require3DGateway($resolver);
-
         $resolver->setDefault('credentials', function (OptionsResolver $subResolver): void {
             $subResolver->setRequired([
                 'terminal_id',
@@ -41,5 +39,10 @@ class PayFlexCPV4PosDefinitionBuilder extends AbstractGatewayDefinitionBuilder
             // enc_key is not used, we set it to empty string by default.
             $subResolver->setDefault('enc_key', '');
         });
+    }
+
+    protected function getRequiredEndpoints(): array
+    {
+        return \array_merge(parent::getRequiredEndpoints(), ['gateway_3d']);
     }
 }

--- a/src/Gateway/Builder/PayFlexCPV4PosDefinitionBuilder.php
+++ b/src/Gateway/Builder/PayFlexCPV4PosDefinitionBuilder.php
@@ -24,7 +24,7 @@ class PayFlexCPV4PosDefinitionBuilder extends AbstractGatewayDefinitionBuilder
     {
         parent::configureOptions($resolver);
 
-        $resolver->setDefault('credentials', function (OptionsResolver $subResolver): void {
+        $this->setNestedOptions($resolver, 'credentials', function (OptionsResolver $subResolver): void {
             $subResolver->setRequired([
                 'terminal_id',
                 'user_password',

--- a/src/Gateway/Builder/PayFlexV4PosDefinitionBuilder.php
+++ b/src/Gateway/Builder/PayFlexV4PosDefinitionBuilder.php
@@ -24,7 +24,7 @@ class PayFlexV4PosDefinitionBuilder extends AbstractGatewayDefinitionBuilder
     {
         parent::configureOptions($resolver);
 
-        $resolver->setDefault('credentials', function (OptionsResolver $subResolver): void {
+        $this->setNestedOptions($resolver, 'credentials', function (OptionsResolver $subResolver): void {
             $subResolver->setRequired([
                 'terminal_id',
                 'user_password',

--- a/src/Gateway/Builder/PayFlexV4PosDefinitionBuilder.php
+++ b/src/Gateway/Builder/PayFlexV4PosDefinitionBuilder.php
@@ -24,14 +24,6 @@ class PayFlexV4PosDefinitionBuilder extends AbstractGatewayDefinitionBuilder
     {
         parent::configureOptions($resolver);
 
-        $this->require3DGateway($resolver);
-
-        $resolver->setDefault('gateway_endpoints', function (OptionsResolver $subResolver): void {
-            $subResolver
-                ->setRequired('query_api')
-                ->setAllowedTypes('query_api', 'string');
-        });
-
         $resolver->setDefault('credentials', function (OptionsResolver $subResolver): void {
             $subResolver->setRequired([
                 'terminal_id',
@@ -47,5 +39,10 @@ class PayFlexV4PosDefinitionBuilder extends AbstractGatewayDefinitionBuilder
             // enc_key is not used, we set it to empty string by default.
             $subResolver->setDefault('enc_key', '');
         });
+    }
+
+    protected function getRequiredEndpoints(): array
+    {
+        return \array_merge(parent::getRequiredEndpoints(), ['gateway_3d', 'query_api']);
     }
 }

--- a/src/Gateway/Builder/PayForPosDefinitionBuilder.php
+++ b/src/Gateway/Builder/PayForPosDefinitionBuilder.php
@@ -25,7 +25,7 @@ class PayForPosDefinitionBuilder extends AbstractGatewayDefinitionBuilder
     {
         parent::configureOptions($resolver);
 
-        $resolver->setDefault('credentials', function (OptionsResolver $subResolver): void {
+        $this->setNestedOptions($resolver, 'credentials', function (OptionsResolver $subResolver): void {
             $subResolver
                 ->setRequired('user_name')
                 ->setAllowedTypes('user_name', ['int', 'string']);

--- a/src/Gateway/Builder/PayForPosDefinitionBuilder.php
+++ b/src/Gateway/Builder/PayForPosDefinitionBuilder.php
@@ -25,8 +25,6 @@ class PayForPosDefinitionBuilder extends AbstractGatewayDefinitionBuilder
     {
         parent::configureOptions($resolver);
 
-        $this->require3DGateway($resolver);
-
         $resolver->setDefault('credentials', function (OptionsResolver $subResolver): void {
             $subResolver
                 ->setRequired('user_name')
@@ -39,5 +37,10 @@ class PayForPosDefinitionBuilder extends AbstractGatewayDefinitionBuilder
                 ->setDefault('mbr_id', PayForAccount::MBR_ID_FINANSBANK)
                 ->setAllowedTypes('mbr_id', ['int', 'string']);
         });
+    }
+
+    protected function getRequiredEndpoints(): array
+    {
+        return \array_merge(parent::getRequiredEndpoints(), ['gateway_3d']);
     }
 }

--- a/src/Gateway/Builder/PosNetPosDefinitionBuilder.php
+++ b/src/Gateway/Builder/PosNetPosDefinitionBuilder.php
@@ -25,7 +25,7 @@ class PosNetPosDefinitionBuilder extends AbstractGatewayDefinitionBuilder
     {
         parent::configureOptions($resolver);
 
-        $resolver->setDefault('credentials', function (OptionsResolver $subResolver): void {
+        $this->setNestedOptions($resolver, 'credentials', function (OptionsResolver $subResolver): void {
 
             $subResolver->setRequired([
                 'terminal_id',

--- a/src/Gateway/Builder/PosNetPosDefinitionBuilder.php
+++ b/src/Gateway/Builder/PosNetPosDefinitionBuilder.php
@@ -25,8 +25,6 @@ class PosNetPosDefinitionBuilder extends AbstractGatewayDefinitionBuilder
     {
         parent::configureOptions($resolver);
 
-        $this->require3DGateway($resolver);
-
         $resolver->setDefault('credentials', function (OptionsResolver $subResolver): void {
 
             $subResolver->setRequired([
@@ -36,5 +34,10 @@ class PosNetPosDefinitionBuilder extends AbstractGatewayDefinitionBuilder
             $subResolver->setAllowedTypes('terminal_id', ['int', 'string']);
             $subResolver->setAllowedTypes('user_name', ['int', 'string']);
         });
+    }
+
+    protected function getRequiredEndpoints(): array
+    {
+        return \array_merge(parent::getRequiredEndpoints(), ['gateway_3d']);
     }
 }

--- a/src/Gateway/Builder/ToslaPosDefinitionBuilder.php
+++ b/src/Gateway/Builder/ToslaPosDefinitionBuilder.php
@@ -24,7 +24,7 @@ class ToslaPosDefinitionBuilder extends AbstractGatewayDefinitionBuilder
     {
         parent::configureOptions($resolver);
 
-        $resolver->setDefault('credentials', function (OptionsResolver $subResolver): void {
+        $this->setNestedOptions($resolver, 'credentials', function (OptionsResolver $subResolver): void {
             $subResolver
                 ->setRequired('user_name')
                 ->setAllowedTypes('user_name', ['int', 'string']);

--- a/src/Gateway/Builder/ToslaPosDefinitionBuilder.php
+++ b/src/Gateway/Builder/ToslaPosDefinitionBuilder.php
@@ -24,8 +24,6 @@ class ToslaPosDefinitionBuilder extends AbstractGatewayDefinitionBuilder
     {
         parent::configureOptions($resolver);
 
-        $this->require3DGateway($resolver);
-
         $resolver->setDefault('credentials', function (OptionsResolver $subResolver): void {
             $subResolver
                 ->setRequired('user_name')
@@ -34,5 +32,10 @@ class ToslaPosDefinitionBuilder extends AbstractGatewayDefinitionBuilder
                 ->setDefined('sub_merchant_id')
                 ->setAllowedTypes('sub_merchant_id', ['int', 'string']);
         });
+    }
+
+    protected function getRequiredEndpoints(): array
+    {
+        return \array_merge(parent::getRequiredEndpoints(), ['gateway_3d']);
     }
 }

--- a/src/Gateway/Builder/VakifKatilimPosDefinitionBuilder.php
+++ b/src/Gateway/Builder/VakifKatilimPosDefinitionBuilder.php
@@ -24,7 +24,7 @@ class VakifKatilimPosDefinitionBuilder extends AbstractGatewayDefinitionBuilder
     {
         parent::configureOptions($resolver);
 
-        $resolver->setDefault('credentials', function (OptionsResolver $subResolver): void {
+        $this->setNestedOptions($resolver, 'credentials', function (OptionsResolver $subResolver): void {
             $subResolver->setRequired([
                 'terminal_id',
                 'user_name'

--- a/src/Gateway/Builder/VakifKatilimPosDefinitionBuilder.php
+++ b/src/Gateway/Builder/VakifKatilimPosDefinitionBuilder.php
@@ -24,8 +24,6 @@ class VakifKatilimPosDefinitionBuilder extends AbstractGatewayDefinitionBuilder
     {
         parent::configureOptions($resolver);
 
-        $this->require3DGateway($resolver);
-
         $resolver->setDefault('credentials', function (OptionsResolver $subResolver): void {
             $subResolver->setRequired([
                 'terminal_id',
@@ -37,5 +35,10 @@ class VakifKatilimPosDefinitionBuilder extends AbstractGatewayDefinitionBuilder
                 ->setDefined('sub_merchant_id')
                 ->setAllowedTypes('sub_merchant_id', ['int', 'string']);
         });
+    }
+
+    protected function getRequiredEndpoints(): array
+    {
+        return \array_merge(parent::getRequiredEndpoints(), ['gateway_3d']);
     }
 }

--- a/src/Gateway/GatewayDefinitionFactory.php
+++ b/src/Gateway/GatewayDefinitionFactory.php
@@ -30,7 +30,7 @@ class GatewayDefinitionFactory
         ];
     }
 
-    public function createDefinition(string $name, array $options): ?Definition
+    public function createDefinition(string $name, array $options): Definition
     {
         foreach ($this->builders as $builder) {
             if ($builder->supports($options['gateway_class'])) {
@@ -38,6 +38,8 @@ class GatewayDefinitionFactory
             }
         }
 
-        return null;
+        throw new \InvalidArgumentException(
+            \sprintf('No builder found for gateway class "%s" (bank: "%s").', $options['gateway_class'], $name)
+        );
     }
 }

--- a/tests/Integration/GatewaysTest.php
+++ b/tests/Integration/GatewaysTest.php
@@ -12,17 +12,24 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class GatewaysTest extends KernelTestCase
 {
-    private ContainerInterface $container;
+    private ContainerInterface $testContainer;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->container = static::getContainer();
+        // getContainer() was added in Symfony 5.3; older versions require bootKernel() first
+        if (method_exists(static::class, 'getContainer')) {
+            $this->testContainer = static::getContainer();
+        } else {
+            // todo remove this when dropping support for Symfony 4
+            static::bootKernel();
+            $this->testContainer = static::$kernel->getContainer();
+        }
     }
 
     public function testEstPos(): void
     {
-        $pos = $this->container->get('test.mews_pos.gateway.estpos');
+        $pos = $this->testContainer->get('test.mews_pos.gateway.estpos');
         $this->assertInstanceOf(\Mews\Pos\Gateways\EstV3Pos::class, $pos);
 
         $this->assertSame('estpos', $pos->getAccount()->getBank());
@@ -42,7 +49,7 @@ class GatewaysTest extends KernelTestCase
 
     public function testPosNet(): void
     {
-        $pos = $this->container->get('test.mews_pos.gateway.yapikredi');
+        $pos = $this->testContainer->get('test.mews_pos.gateway.yapikredi');
         $this->assertInstanceOf(\Mews\Pos\Gateways\PosNet::class, $pos);
 
         $this->assertSame('yapikredi', $pos->getAccount()->getBank());
@@ -58,7 +65,7 @@ class GatewaysTest extends KernelTestCase
 
     public function testPosNetV1(): void
     {
-        $pos = $this->container->get('test.mews_pos.gateway.albaraka');
+        $pos = $this->testContainer->get('test.mews_pos.gateway.albaraka');
         $this->assertInstanceOf(\Mews\Pos\Gateways\PosNetV1Pos::class, $pos);
 
         $this->assertSame('albaraka', $pos->getAccount()->getBank());
@@ -77,7 +84,7 @@ class GatewaysTest extends KernelTestCase
 
     public function testPayForPos(): void
     {
-        $pos = $this->container->get('test.mews_pos.gateway.payfor_finansbank');
+        $pos = $this->testContainer->get('test.mews_pos.gateway.payfor_finansbank');
         $this->assertInstanceOf(\Mews\Pos\Gateways\PayForPos::class, $pos);
 
         $this->assertSame('payfor_finansbank', $pos->getAccount()->getBank());
@@ -98,7 +105,7 @@ class GatewaysTest extends KernelTestCase
 
     public function testPayForPosZiraatKatilim(): void
     {
-        $pos = $this->container->get('test.mews_pos.gateway.payfor_ziraat_katilim');
+        $pos = $this->testContainer->get('test.mews_pos.gateway.payfor_ziraat_katilim');
         $this->assertInstanceOf(\Mews\Pos\Gateways\PayForPos::class, $pos);
 
         $this->assertSame('payfor_ziraat_katilim', $pos->getAccount()->getBank());
@@ -119,7 +126,7 @@ class GatewaysTest extends KernelTestCase
 
     public function testGarantiPos(): void
     {
-        $pos = $this->container->get('test.mews_pos.gateway.garanti');
+        $pos = $this->testContainer->get('test.mews_pos.gateway.garanti');
         $this->assertInstanceOf(\Mews\Pos\Gateways\GarantiPos::class, $pos);
 
         $this->assertSame('garanti', $pos->getAccount()->getBank());
@@ -138,7 +145,7 @@ class GatewaysTest extends KernelTestCase
 
     public function testInterPos(): void
     {
-        $pos = $this->container->get('test.mews_pos.gateway.interpos_denizbank');
+        $pos = $this->testContainer->get('test.mews_pos.gateway.interpos_denizbank');
         $this->assertInstanceOf(\Mews\Pos\Gateways\InterPos::class, $pos);
 
         $this->assertSame('interpos_denizbank', $pos->getAccount()->getBank());
@@ -158,7 +165,7 @@ class GatewaysTest extends KernelTestCase
 
     public function testKuveytPos(): void
     {
-        $pos = $this->container->get('test.mews_pos.gateway.kuveytpos');
+        $pos = $this->testContainer->get('test.mews_pos.gateway.kuveytpos');
         $this->assertInstanceOf(\Mews\Pos\Gateways\KuveytPos::class, $pos);
 
         $this->assertSame('kuveytpos', $pos->getAccount()->getBank());
@@ -178,7 +185,7 @@ class GatewaysTest extends KernelTestCase
 
     public function testVakifKatilimPos(): void
     {
-        $pos = $this->container->get('test.mews_pos.gateway.vakifkatilim');
+        $pos = $this->testContainer->get('test.mews_pos.gateway.vakifkatilim');
         $this->assertInstanceOf(\Mews\Pos\Gateways\VakifKatilimPos::class, $pos);
 
         $this->assertSame('vakifkatilim', $pos->getAccount()->getBank());
@@ -204,7 +211,7 @@ class GatewaysTest extends KernelTestCase
 
     public function testPayFlexV4Pos(): void
     {
-        $pos = $this->container->get('test.mews_pos.gateway.payflexv4_ziraat');
+        $pos = $this->testContainer->get('test.mews_pos.gateway.payflexv4_ziraat');
         $this->assertInstanceOf(\Mews\Pos\Gateways\PayFlexV4Pos::class, $pos);
 
         $this->assertSame('payflexv4_ziraat', $pos->getAccount()->getBank());
@@ -226,7 +233,7 @@ class GatewaysTest extends KernelTestCase
 
     public function testPayFlexCPV4Pos(): void
     {
-        $pos = $this->container->get('test.mews_pos.gateway.payflexcpv4_vakifbank');
+        $pos = $this->testContainer->get('test.mews_pos.gateway.payflexcpv4_vakifbank');
         $this->assertInstanceOf(\Mews\Pos\Gateways\PayFlexCPV4Pos::class, $pos);
 
         $this->assertSame('payflexcpv4_vakifbank', $pos->getAccount()->getBank());
@@ -247,7 +254,7 @@ class GatewaysTest extends KernelTestCase
 
     public function testAkbankPos(): void
     {
-        $pos = $this->container->get('test.mews_pos.gateway.akbankpos');
+        $pos = $this->testContainer->get('test.mews_pos.gateway.akbankpos');
         $this->assertInstanceOf(\Mews\Pos\Gateways\AkbankPos::class, $pos);
 
         $this->assertSame('akbankpos', $pos->getAccount()->getBank());
@@ -275,7 +282,7 @@ class GatewaysTest extends KernelTestCase
 
     public function testToslaPos(): void
     {
-        $pos = $this->container->get('test.mews_pos.gateway.toslapos');
+        $pos = $this->testContainer->get('test.mews_pos.gateway.toslapos');
         $this->assertInstanceOf(\Mews\Pos\Gateways\ToslaPos::class, $pos);
 
         $this->assertSame('toslapos', $pos->getAccount()->getBank());
@@ -301,7 +308,7 @@ class GatewaysTest extends KernelTestCase
 
     public function testParamPos(): void
     {
-        $pos = $this->container->get('test.mews_pos.gateway.parampos');
+        $pos = $this->testContainer->get('test.mews_pos.gateway.parampos');
         $this->assertInstanceOf(\Mews\Pos\Gateways\ParamPos::class, $pos);
 
         $this->assertSame('parampos', $pos->getAccount()->getBank());

--- a/tests/Unit/Gateway/AccountFactoryTest.php
+++ b/tests/Unit/Gateway/AccountFactoryTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Mews\PosBundle\Tests\Unit\Gateway;
+
+use Mews\Pos\PosInterface;
+use Mews\PosBundle\Gateway\AccountFactory;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Mews\PosBundle\Gateway\AccountFactory
+ */
+class AccountFactoryTest extends TestCase
+{
+    public function testThrowsDomainExceptionForUnknownGatewayClass(): void
+    {
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage('App\UnknownGateway');
+
+        AccountFactory::createAccount(
+            'App\UnknownGateway',
+            'mybank',
+            [
+                'payment_model' => PosInterface::MODEL_3D_SECURE,
+                'merchant_id'   => '123',
+                'enc_key'       => 'key',
+            ],
+        );
+    }
+}

--- a/tests/Unit/Gateway/Builder/AbstractGatewayDefinitionBuilderTest.php
+++ b/tests/Unit/Gateway/Builder/AbstractGatewayDefinitionBuilderTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Mews\PosBundle\Tests\Unit\Gateway\Builder;
+
+use Mews\Pos\Gateways\EstV3Pos;
+use Mews\Pos\PosInterface;
+use Mews\PosBundle\Exception\MissingExtensionException;
+use Mews\PosBundle\Gateway\Builder\AbstractGatewayDefinitionBuilder;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Mews\PosBundle\Gateway\Builder\AbstractGatewayDefinitionBuilder
+ */
+class AbstractGatewayDefinitionBuilderTest extends TestCase
+{
+    public function testThrowsMissingExtensionExceptionWhenExtensionNotLoaded(): void
+    {
+        $builder = new class extends AbstractGatewayDefinitionBuilder {
+            public function supports(string $gatewayClass): bool { return true; }
+            protected function getRequiredExtensions(): array
+            {
+                return ['this_extension_does_not_exist' => 'ext-nonexistent'];
+            }
+        };
+
+        $this->expectException(MissingExtensionException::class);
+        $this->expectExceptionMessage('ext-nonexistent');
+
+        $builder->createDefinition('test', [
+            'gateway_class'     => EstV3Pos::class,
+            'credentials'       => [
+                'payment_model' => PosInterface::MODEL_3D_SECURE,
+                'merchant_id'   => '123',
+                'user_name'     => 'user',
+                'user_password' => 'pass',
+                'enc_key'       => 'key',
+            ],
+            'gateway_endpoints' => [
+                'payment_api' => 'https://api.example.com',
+                'gateway_3d'  => 'https://3d.example.com',
+            ],
+        ]);
+    }
+}

--- a/tests/Unit/Gateway/Builder/EstV3PosDefinitionBuilderTest.php
+++ b/tests/Unit/Gateway/Builder/EstV3PosDefinitionBuilderTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Mews\PosBundle\Tests\Unit\Gateway\Builder;
+
+use Mews\Pos\Gateways\EstV3Pos;
+use Mews\Pos\PosInterface;
+use Mews\PosBundle\Gateway\Builder\EstV3PosDefinitionBuilder;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
+use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
+
+/**
+ * @covers \Mews\PosBundle\Gateway\Builder\EstV3PosDefinitionBuilder
+ * @covers \Mews\PosBundle\Gateway\Builder\AbstractGatewayDefinitionBuilder
+ */
+class EstV3PosDefinitionBuilderTest extends TestCase
+{
+    private EstV3PosDefinitionBuilder $builder;
+
+    protected function setUp(): void
+    {
+        $this->builder = new EstV3PosDefinitionBuilder();
+    }
+
+    private function validOptions(): array
+    {
+        return [
+            'gateway_class'     => EstV3Pos::class,
+            'credentials'       => [
+                'payment_model' => PosInterface::MODEL_3D_SECURE,
+                'merchant_id'   => 'merchant',
+                'user_name'     => 'user',
+                'user_password' => 'pass',
+                'enc_key'       => 'key',
+            ],
+            'gateway_endpoints' => [
+                'payment_api' => 'https://api.example.com',
+                'gateway_3d'  => 'https://3d.example.com',
+            ],
+        ];
+    }
+
+    public function testCreatesDefinitionWithValidOptions(): void
+    {
+        $definition = $this->builder->createDefinition('estpos', $this->validOptions());
+        $this->assertNotNull($definition);
+    }
+
+    public function testThrowsWhenPaymentApiMissing(): void
+    {
+        $options = $this->validOptions();
+        unset($options['gateway_endpoints']['payment_api']);
+
+        $this->expectException(MissingOptionsException::class);
+        $this->builder->createDefinition('estpos', $options);
+    }
+
+    public function testThrowsWhenGateway3dMissing(): void
+    {
+        $options = $this->validOptions();
+        unset($options['gateway_endpoints']['gateway_3d']);
+
+        $this->expectException(MissingOptionsException::class);
+        $this->builder->createDefinition('estpos', $options);
+    }
+
+    public function testThrowsWhenUserNameMissing(): void
+    {
+        $options = $this->validOptions();
+        unset($options['credentials']['user_name']);
+
+        $this->expectException(MissingOptionsException::class);
+        $this->builder->createDefinition('estpos', $options);
+    }
+
+    public function testThrowsWhenUserPasswordMissing(): void
+    {
+        $options = $this->validOptions();
+        unset($options['credentials']['user_password']);
+
+        $this->expectException(MissingOptionsException::class);
+        $this->builder->createDefinition('estpos', $options);
+    }
+
+    public function testThrowsWhenPaymentModelIsInvalid(): void
+    {
+        $options = $this->validOptions();
+        $options['credentials']['payment_model'] = 'invalid_model';
+
+        $this->expectException(InvalidOptionsException::class);
+        $this->builder->createDefinition('estpos', $options);
+    }
+}

--- a/tests/Unit/Gateway/GatewayDefinitionFactoryTest.php
+++ b/tests/Unit/Gateway/GatewayDefinitionFactoryTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Mews\PosBundle\Tests\Unit\Gateway;
+
+use Mews\Pos\Gateways\EstV3Pos;
+use Mews\PosBundle\Gateway\GatewayDefinitionFactory;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Mews\PosBundle\Gateway\GatewayDefinitionFactory
+ */
+class GatewayDefinitionFactoryTest extends TestCase
+{
+    private GatewayDefinitionFactory $factory;
+
+    protected function setUp(): void
+    {
+        $this->factory = new GatewayDefinitionFactory();
+    }
+
+    public function testCreateDefinitionThrowsForUnknownGatewayClass(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('No builder found for gateway class "App\NonExistentGateway" (bank: "mybank").');
+
+        $this->factory->createDefinition('mybank', [
+            'gateway_class' => 'App\NonExistentGateway',
+        ]);
+    }
+
+    public function testCreateDefinitionReturnsDefinitionForKnownGatewayClass(): void
+    {
+        $definition = $this->factory->createDefinition('estpos', [
+            'gateway_class'      => EstV3Pos::class,
+            'lang'               => 'tr',
+            'test_mode'          => false,
+            'credentials'        => [
+                'payment_model' => 'regular',
+                'merchant_id'   => '700XXX',
+                'user_name'     => 'user',
+                'user_password' => 'pass',
+                'enc_key'       => 'key',
+            ],
+            'gateway_endpoints'  => [
+                'payment_api' => 'https://example.com/api',
+                'gateway_3d'  => 'https://example.com/3d',
+            ],
+            'gateway_configs'    => [],
+        ]);
+
+        $this->assertNotNull($definition);
+    }
+}

--- a/tests/Unit/Gateway/GatewayFactoryTest.php
+++ b/tests/Unit/Gateway/GatewayFactoryTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Mews\PosBundle\Tests\Unit\Gateway;
+
+use Mews\Pos\PosInterface;
+use Mews\PosBundle\Gateway\GatewayFactory;
+use PHPUnit\Framework\TestCase;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @covers \Mews\PosBundle\Gateway\GatewayFactory
+ */
+class GatewayFactoryTest extends TestCase
+{
+    public function testThrowsForClassNotImplementingPosInterface(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('gateway_class must be implementation of ' . PosInterface::class);
+
+        GatewayFactory::createPosGateway(
+            'test',
+            [
+                'gateway_class'      => \stdClass::class,
+                'credentials'        => [],
+                'gateway_endpoints'  => [],
+                'gateway_configs'    => [],
+            ],
+            $this->createMock(EventDispatcherInterface::class),
+            $this->createMock(LoggerInterface::class),
+            $this->createMock(ClientInterface::class),
+        );
+    }
+}

--- a/tests/config/framework.yaml
+++ b/tests/config/framework.yaml
@@ -1,6 +1,5 @@
 framework:
   http_method_override: false
-  handle_all_throwables: true
   php_errors:
     log: true
   test: true

--- a/tests/config/mews_pos.yaml
+++ b/tests/config/mews_pos.yaml
@@ -120,7 +120,7 @@ mews_pos:
       gateway_class: Mews\Pos\Gateways\PayFlexV4Pos
       credentials:
         payment_model: !php/const Mews\Pos\PosInterface::MODEL_3D_SECURE
-        merchant_id: 000000000111111
+        merchant_id: '000000000111111'
         terminal_id: VP000095
         user_password: 3XTgER89as
       gateway_endpoints:
@@ -131,7 +131,7 @@ mews_pos:
       gateway_class: Mews\Pos\Gateways\PayFlexCPV4Pos
       credentials:
         payment_model: !php/const Mews\Pos\PosInterface::MODEL_3D_PAY
-        merchant_id: 000100000013506
+        merchant_id: '000100000013506'
         terminal_id: VP000579
         user_password: 123456
       gateway_endpoints:


### PR DESCRIPTION
### Eklendi
- Symfony 8 desteği eklendi (`symfony/config`, `symfony/dependency-injection`, `symfony/http-kernel` vb. bağımlılıklar `^8.0` sürümüyle genişletildi)
- CI pipeline'a PHP 8.4 ve Symfony 8 test matrisi eklendi
- Unit testler eklendi: `AccountFactoryTest`, `AbstractGatewayDefinitionBuilderTest`, `EstV3PosDefinitionBuilderTest`, `GatewayFactoryTest`, `GatewayDefinitionFactoryTest`

### Düzeltildi
- `AbstractGatewayDefinitionBuilder`'da `require3DGateway()` çağrısı, üst sınıfın `gateway_endpoints` alt çözücüsünü sessizce üzerine yazarak `payment_api` zorunluluğunu ve `gateway_3d_host` tanımını siliyordu. Mevcut alt çözücünün genişletilmesiyle bu hata giderildi.

### Yeniden Düzenlendi
- `GatewayDefinitionFactory`: Yapılandırmada desteklenmeyen bir `gateway_class` tanımlandığında artık açıklayıcı bir `InvalidArgumentException` fırlatılıyor
- `AbstractGatewayDefinitionBuilder`: PHP eklentisi kontrolü basitleştirildi
- KuveytPos için PHP `ext-soap` eklendi zorunluluğu kaldırıldı
- `AccountFactory`: Hata mesajı daha açıklayıcı hale getirildi
